### PR TITLE
Prevent surrogate call ambiguity

### DIFF
--- a/tests/fuzztests/fuzztests.cpp
+++ b/tests/fuzztests/fuzztests.cpp
@@ -672,8 +672,8 @@ void on_signal(int signal)
 extern "C" void signal_handler(int signal)
 {
 	on_signal(signal);
-	if (g_prev_sigsegv.load(std::memory_order_relaxed) != nullptr) {
-		g_prev_sigsegv(signal);
+	if (signal_handler_t handler_fn = g_prev_sigsegv.load(std::memory_order_relaxed)) {
+		handler_fn(signal);
 	}
 	else {
 		std::exit(signal);


### PR DESCRIPTION
Compiling the test suite with Visual Studio 2015 Update 1 results in two compiler errors:

 - One in `boost::lockfree::queue<T>`'s constructor, which is fixable by updating from Boost 1.55 to a more recent version (it works fine with 1.60 in my tests). This PR does not include an updated Boost.

 - One in [`tests/fuzztests.cpp`](https://github.com/cameron314/concurrentqueue/blob/5ec729e63560a01f3dadc1f58d07b36bbd76a373/tests/fuzztests/fuzztests.cpp#L675-L677):

```
if (g_prev_sigsegv.load(std::memory_order_relaxed) != nullptr) {
  g_prev_sigsegv(signal);
}
```

This is a subtle one; `std::atomic<signal_handler_t>` has two implicit conversion operators—[`operator signal_handler_t() const` and `operator signal_handler_t() const volatile`](http://en.cppreference.com/w/cpp/atomic/atomic/operator_T). According to the standard ([N4567](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4567.pdf), §13.3.1.1.2) when an object of class type is called, for each of these conversion operators an implicit *surrogate call* is added to the overload set, of the form

```
void call-function(signal_handler_t handler_fn, int signal) { return handler_fn(signal); }
```

But because each of these surrogate calls does not take the cv-qualification of the class into account, we end up with two repeated function signatures in the overload set, and thus an ambiguity. See [this answer](https://stackoverflow.com/a/22352944) for more. This happens to work with GCC and Visual Studio 2013, but Clang and Visual Studio 2015 no longer accept this code—and they happen to be right. This also addresses #35.
