### PR TITLE
Include TargetConditionals.h for Apple platforms.

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -42,6 +42,10 @@
 #endif
 #endif
 
+#if defined(__APPLE__)
+#include "TargetConditionals.h"
+#endif
+
 #ifdef MCDBGQ_USE_RELACY
 #include "relacy/relacy_std.hpp"
 #include "relacy_shims.h"


### PR DESCRIPTION
TARGET_OS_IPHONE (used in concurrentqueue.h) is defined in
TargetConditionals.h