### PR TITLE
Support running unit tests on iOS device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/msvc12/*.log
 build/msvc12/obj/
 build/msvc11/*.log
 build/msvc11/obj/
+build/xcode/build/
 tests/fuzztests/fuzztests.log
 benchmarks/benchmarks.log
 tests/CDSChecker/*.o

--- a/build/xcode/Info.plist
+++ b/build/xcode/Info.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/build/xcode/concurrentqueue.xcodeproj/project.pbxproj
+++ b/build/xcode/concurrentqueue.xcodeproj/project.pbxproj
@@ -1,0 +1,292 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CFBF030B1C595BD60042518B /* simplethread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CFBF03011C595BD60042518B /* simplethread.cpp */; };
+		CFBF030C1C595BD60042518B /* systemtime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CFBF03031C595BD60042518B /* systemtime.cpp */; };
+		CFBF030E1C595BD60042518B /* mallocmacro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CFBF03081C595BD60042518B /* mallocmacro.cpp */; };
+		CFBF030F1C595BD60042518B /* unittests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CFBF030A1C595BD60042518B /* unittests.cpp */; };
+		CFBF03121C5962CD0042518B /* main_ios.mm in Sources */ = {isa = PBXBuildFile; fileRef = CFBF03101C595FBF0042518B /* main_ios.mm */; };
+		CFBF03141C5962E60042518B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFBF03131C5962E60042518B /* UIKit.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		CFBF02E41C595A0F0042518B /* concurrentqueue-unittests-ios.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "concurrentqueue-unittests-ios.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CFBF03011C595BD60042518B /* simplethread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = simplethread.cpp; sourceTree = "<group>"; };
+		CFBF03021C595BD60042518B /* simplethread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simplethread.h; sourceTree = "<group>"; };
+		CFBF03031C595BD60042518B /* systemtime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = systemtime.cpp; sourceTree = "<group>"; };
+		CFBF03041C595BD60042518B /* systemtime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = systemtime.h; sourceTree = "<group>"; };
+		CFBF03081C595BD60042518B /* mallocmacro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mallocmacro.cpp; sourceTree = "<group>"; };
+		CFBF03091C595BD60042518B /* minitest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = minitest.h; sourceTree = "<group>"; };
+		CFBF030A1C595BD60042518B /* unittests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unittests.cpp; sourceTree = "<group>"; };
+		CFBF03101C595FBF0042518B /* main_ios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = main_ios.mm; sourceTree = "<group>"; };
+		CFBF03131C5962E60042518B /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CFBF02E11C595A0F0042518B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CFBF03141C5962E60042518B /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CFBF02CB1C5959990042518B = {
+			isa = PBXGroup;
+			children = (
+				CFBF03101C595FBF0042518B /* main_ios.mm */,
+				CFBF03001C595BD60042518B /* common */,
+				CFBF03061C595BD60042518B /* unittests */,
+				CFBF02D51C5959990042518B /* Products */,
+				CFBF03131C5962E60042518B /* UIKit.framework */,
+			);
+			sourceTree = "<group>";
+		};
+		CFBF02D51C5959990042518B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CFBF02E41C595A0F0042518B /* concurrentqueue-unittests-ios.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CFBF03001C595BD60042518B /* common */ = {
+			isa = PBXGroup;
+			children = (
+				CFBF03011C595BD60042518B /* simplethread.cpp */,
+				CFBF03021C595BD60042518B /* simplethread.h */,
+				CFBF03031C595BD60042518B /* systemtime.cpp */,
+				CFBF03041C595BD60042518B /* systemtime.h */,
+			);
+			name = common;
+			path = ../../tests/common;
+			sourceTree = "<group>";
+		};
+		CFBF03061C595BD60042518B /* unittests */ = {
+			isa = PBXGroup;
+			children = (
+				CFBF03081C595BD60042518B /* mallocmacro.cpp */,
+				CFBF03091C595BD60042518B /* minitest.h */,
+				CFBF030A1C595BD60042518B /* unittests.cpp */,
+			);
+			name = unittests;
+			path = ../../tests/unittests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CFBF02E31C595A0F0042518B /* concurrentqueue-unittests-ios */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CFBF02F81C595A0F0042518B /* Build configuration list for PBXNativeTarget "concurrentqueue-unittests-ios" */;
+			buildPhases = (
+				CFBF02E01C595A0F0042518B /* Sources */,
+				CFBF02E11C595A0F0042518B /* Frameworks */,
+				CFBF02E21C595A0F0042518B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "concurrentqueue-unittests-ios";
+			productName = "concurrentqueue-unittests-ios";
+			productReference = CFBF02E41C595A0F0042518B /* concurrentqueue-unittests-ios.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CFBF02CC1C5959990042518B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = cameron314;
+				TargetAttributes = {
+					CFBF02E31C595A0F0042518B = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
+			};
+			buildConfigurationList = CFBF02CF1C5959990042518B /* Build configuration list for PBXProject "concurrentqueue" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CFBF02CB1C5959990042518B;
+			productRefGroup = CFBF02D51C5959990042518B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CFBF02E31C595A0F0042518B /* concurrentqueue-unittests-ios */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CFBF02E21C595A0F0042518B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CFBF02E01C595A0F0042518B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CFBF03121C5962CD0042518B /* main_ios.mm in Sources */,
+				CFBF030C1C595BD60042518B /* systemtime.cpp in Sources */,
+				CFBF030E1C595BD60042518B /* mallocmacro.cpp in Sources */,
+				CFBF030B1C595BD60042518B /* simplethread.cpp in Sources */,
+				CFBF030F1C595BD60042518B /* unittests.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		CFBF02DB1C5959990042518B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		CFBF02DC1C5959990042518B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CFBF02F91C595A0F0042518B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_THREADSAFE_STATICS = NO;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "cameron314.concurrentqueue-unittests-ios";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CFBF02FA1C595A0F0042518B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
+				GCC_THREADSAFE_STATICS = NO;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "cameron314.concurrentqueue-unittests-ios";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CFBF02CF1C5959990042518B /* Build configuration list for PBXProject "concurrentqueue" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CFBF02DB1C5959990042518B /* Debug */,
+				CFBF02DC1C5959990042518B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CFBF02F81C595A0F0042518B /* Build configuration list for PBXNativeTarget "concurrentqueue-unittests-ios" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CFBF02F91C595A0F0042518B /* Debug */,
+				CFBF02FA1C595A0F0042518B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CFBF02CC1C5959990042518B /* Project object */;
+}

--- a/build/xcode/concurrentqueue.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/build/xcode/concurrentqueue.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:concurrentqueue.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/build/xcode/concurrentqueue.xcodeproj/xcshareddata/xcschemes/concurrentqueue-unittests-ios.xcscheme
+++ b/build/xcode/concurrentqueue.xcodeproj/xcshareddata/xcschemes/concurrentqueue-unittests-ios.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CFBF02E31C595A0F0042518B"
+               BuildableName = "concurrentqueue-unittests-ios.app"
+               BlueprintName = "concurrentqueue-unittests-ios"
+               ReferencedContainer = "container:concurrentqueue.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CFBF02E31C595A0F0042518B"
+            BuildableName = "concurrentqueue-unittests-ios.app"
+            BlueprintName = "concurrentqueue-unittests-ios"
+            ReferencedContainer = "container:concurrentqueue.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CFBF02E31C595A0F0042518B"
+            BuildableName = "concurrentqueue-unittests-ios.app"
+            BlueprintName = "concurrentqueue-unittests-ios"
+            ReferencedContainer = "container:concurrentqueue.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CFBF02E31C595A0F0042518B"
+            BuildableName = "concurrentqueue-unittests-ios.app"
+            BlueprintName = "concurrentqueue-unittests-ios"
+            ReferencedContainer = "container:concurrentqueue.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/build/xcode/main_ios.mm
+++ b/build/xcode/main_ios.mm
@@ -1,0 +1,39 @@
+#import <UIKit/UIKit.h>
+
+// runAllTests should be defined by the main unit test compilation
+// unit (unittests.cpp)
+bool runAllTests();
+
+// Define a minimal UIApplicationDelegate.
+@interface AppDelegate : NSObject <UIApplicationDelegate>
+@property (nonatomic, strong) UIWindow *window;
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(__unused UIApplication *)application
+    didFinishLaunchingWithOptions:(__unused NSDictionary *)launchOptions {
+  // Xcode / iOS will complain unless a window and a root view
+  // controller is setup at application launch.
+  self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+  self.window.rootViewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
+  [self.window makeKeyAndVisible];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self run];
+  });
+  return YES;
+}
+
+-(void) run {
+  NSLog(@"Starting unittests run...");
+  const bool result = runAllTests();
+  NSLog(@"%@", result ? @"All tests passed" : @"Test(s) failed!");
+}
+
+@end
+
+int main(int argc, char *argv[]) {
+  @autoreleasepool {
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+  }
+}

--- a/tests/corealgos.h
+++ b/tests/corealgos.h
@@ -76,6 +76,10 @@ private:
 // Thread local hash map
 ////////////////////////////////////////////////////////////////////////////////
 
+#if defined(__APPLE__)
+#include "TargetConditionals.h" // Needed for TARGET_OS_IPHONE
+#endif
+
 // Platform-specific definitions of a numeric thread ID type and an invalid value
 #if defined(_WIN32) || defined(__WINDOWS__) || defined(__WIN32__)
 // No sense pulling in windows.h in a header, we'll manually declare the function
@@ -86,6 +90,12 @@ namespace moodycamel { namespace corealgos { namespace details {
 	typedef std::uint32_t thread_id_t;
 	static const thread_id_t invalid_thread_id = 0;		// See http://blogs.msdn.com/b/oldnewthing/archive/2004/02/23/78395.aspx
 	static inline thread_id_t thread_id() { return static_cast<thread_id_t>(::GetCurrentThreadId()); }
+} } }
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+namespace moodycamel { namespace corealgos { namespace details {
+	typedef std::uintptr_t thread_id_t;
+	static const thread_id_t invalid_thread_id = 0;
+	static inline thread_id_t thread_id() { return std::hash<std::thread::id>()(std::this_thread::get_id()); }
 } } }
 #else
 // Use a nice trick from this answer: http://stackoverflow.com/a/8438730/21475

--- a/tests/unittests/unittests.cpp
+++ b/tests/unittests/unittests.cpp
@@ -4401,6 +4401,7 @@ void printTests(ConcurrentQueueTests const& tests)
 
 
 // Basic test harness
+#if !defined(TARGET_OS_IPHONE)
 int main(int argc, char** argv)
 {
 	bool disablePrompt = false;
@@ -4508,3 +4509,12 @@ int main(int argc, char** argv)
 	}
 	return exitCode;
 }
+#else
+// Provide entry function that can be invoked
+// by a test host (iOS app / test runner)
+bool runAllTests() {
+  unsigned int iterations = 8;
+  ConcurrentQueueTests tests;
+  return tests.run(iterations);
+}
+#endif // !defined(TARGET_OS_IPHONE)


### PR DESCRIPTION
Added a minimal Xcode project with a iOS Application target that
provides a minimal UIApplicationDelegate that can host / run the unit
tests.

The target is intentionally setup as an "Application"-type target rather
than an XCTest bundle as it is generally easier to run application
targets on device (vs iOS Simulator).

Explicitly enabled build settings:

  Release configuration: NDEBUG=1

The commited shared .xcscheme is set to build and tests in Release.