### PR TITLE
fix the ifdef for max_align_t for use with clang

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -237,7 +237,7 @@ namespace details {
 			: static_cast<T>(-1);
 	};
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined( __clang__ )
 	typedef ::max_align_t max_align_t;      // GCC forgot to add it to std:: for a while
 #else
 	typedef std::max_align_t max_align_t;   // Others (e.g. MSVC) insist it can *only* be accessed via std::


### PR DESCRIPTION
It seems that clang defines __GNUC__ but doesn't have the same problems as gcc, so I added this extra check