### PR TITLE
Conan.io package recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ tests/CDSChecker/model-checker/
 tests/relacy/freelist.exe
 tests/relacy/spmchash.exe
 tests/relacy/log.txt
+test_package/build/
+*.pyc

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,21 @@
+from conans import ConanFile
+import os
+
+class ConcurrentQueue(ConanFile):
+    name = "concurrentqueue"
+    url = 'https://github.com/Manu343726/concurrentqueue'
+    description='A fast multi-producer, multi-consumer lock-free queue for C++11'
+    license = "Simplified BSD/Boost Software License"
+    version = "1.0.0"
+    exports = "*.h"
+    build_policy = "missing"
+    generators = 'cmake'
+
+    def package(self):
+        include_dir  = os.path.join('include', 'concurrentqueue')
+        include_dir2 = os.path.join('include', 'moodycamel')
+
+        self.copy('concurrentqueue.h', dst=include_dir)
+        self.copy('blockingconcurrentqueue.h', dst=include_dir)
+        self.copy('concurrentqueue.h', dst=include_dir2)
+        self.copy('blockingconcurrentqueue.h', dst=include_dir2)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(concurrentqueue_test_package)
+cmake_minimum_required(VERSION 2.8)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+conan_define_targets()
+
+add_executable(example main.cpp)
+if(NOT MSVC)
+    target_compile_options(example PRIVATE -std=c++11)
+endif()
+
+find_package(Threads)
+target_link_libraries(example PRIVATE CONAN_PKG::concurrentqueue ${CMAKE_THREAD_LIBS_INIT})

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,21 @@
+from conans import ConanFile, CMake
+import os
+
+version = os.getenv('CONAN_CONCURRENTQUEUE_VERSION', '1.0.0')
+user    = os.getenv('CONAN_CONCURRENTQUEUE_USER', 'Manu343726')
+channel = os.getenv('CONAN_CONCURRENTQUEUE_CHANNEL', 'testing')
+
+class TestConcurrentQueue(ConanFile):
+    settings = 'os', 'compiler', 'build_type', 'arch'
+    requires = (
+        'concurrentqueue/{}@{}/{}'.format(version, user, channel)
+    )
+    generators = 'cmake'
+
+    def build(self):
+        cmake = CMake(self.settings)
+        self.run('cmake {} {}'.format(self.conanfile_directory, cmake.command_line))
+        self.run('cmake --build . {}'.format(cmake.build_config))
+
+    def test(self):
+        self.run(os.path.join('.', 'bin', 'example'))

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -1,0 +1,53 @@
+/*
+ * Hello concurrency example from samples.md
+ */
+
+#include <moodycamel/concurrentqueue.h>
+#include <cassert>
+#include <thread>
+
+using namespace moodycamel;
+
+int main()
+{
+    ConcurrentQueue<int> q;
+    int dequeued[100] = { 0 };
+    std::thread threads[20];
+
+    // Producers
+    for (int i = 0; i != 10; ++i) {
+        threads[i] = std::thread([&](int i) {
+            for (int j = 0; j != 10; ++j) {
+                q.enqueue(i * 10 + j);
+            }
+        }, i);
+    }
+
+    // Consumers
+    for (int i = 10; i != 20; ++i) {
+        threads[i] = std::thread([&]() {
+            int item;
+            for (int j = 0; j != 20; ++j) {
+                if (q.try_dequeue(item)) {
+                    ++dequeued[item];
+                }
+            }
+        });
+    }
+
+    // Wait for all threads
+    for (int i = 0; i != 20; ++i) {
+        threads[i].join();
+    }
+
+    // Collect any leftovers (could be some if e.g. consumers finish before producers)
+    int item;
+    while (q.try_dequeue(item)) {
+        ++dequeued[item];
+    }
+
+    // Make sure everything went in and came back out!
+    for (int i = 0; i != 100; ++i) {
+        assert(dequeued[i] == 1);
+    }
+}


### PR DESCRIPTION
Hi,

This PR is the equivalent of https://github.com/cameron314/readerwriterqueue/pull/41 for your multiple producer/consumer queue. I have the habit of pushing new conan packages as I need them, and I've been playing with a job-stealing task engine, so... here we are ;)

As with readerwriterqueue, this PR adds the minimal stuff to maintain a package in conan.io:

 - `conanfile.py`: The package recipe, signed as version 1.0.0
 - `test_package/`: An example cmake project consuming the package, to test if everything is working. I picked up the "Hello concurrency" example from your `samples.md`.

*The travis stuff and badges are missing, I will try to add them too later*.

One difference from the readerwriterqueue package is that I exported your headers into two include dirs, `concurrentqueue` (similar to what's done in readerwriterqueue) and `moodycamel`, since I thought `#include`ing your lib as `#include <moodycamel/concurrentqueue.hpp>` would make more sense. If you like it I could patch the readerwriterqueue recipe to also export to `moodycamel`.

Cheers.