### PR TITLE
Adding support for super-aligned types

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -3550,7 +3550,7 @@ private:
 	static inline U* create_array(size_t count)
 	{
 		assert(count > 0);
-		auto p = static_cast<U*>((Traits::aligned_malloc)(sizeof(U) * count, aligneof(U)));
+		auto p = static_cast<U*>((Traits::aligned_malloc)(sizeof(U) * count, alignof(U)));
 		if (p == nullptr) {
 			return nullptr;
 		}

--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -3492,12 +3492,6 @@ private:
 	// Utility functions
 	//////////////////////////////////
 
-	template<typename T>
-	struct SuperAlignPad {
-		T item;
-		void* start;
-	};
-
 	// Fundamental alignment
 
 	template<typename U, typename std::enable_if<!(alignof(U)>alignof(std::max_align_t)), int>::type = 0>

--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -331,16 +331,16 @@ struct ConcurrentQueueDefaultTraits
 #endif
 	static inline void* aligned_malloc(size_t size, size_t alignment){
 		void* res = nullptr;
-        void* ptr = malloc(size + alignment);
-        if(ptr != nullptr) {
-            res = reinterpret_cast<void*>((reinterpret_cast<size_t>(ptr) & ~(size_t(alignment - 1))) + alignment);
-            *(reinterpret_cast<void**>(res) - 1) = ptr;
-        }
-        return res;
+		void* ptr = malloc(size + alignment);
+		if(ptr != nullptr) {
+			res = reinterpret_cast<void*>((reinterpret_cast<size_t>(ptr) & ~(size_t(alignment - 1))) + alignment);
+			*(reinterpret_cast<void**>(res) - 1) = ptr;
+		}
+		return res;
 	}
 	static inline void aligned_free(void* ptr){
 		if(ptr != nullptr)
-            free(*(reinterpret_cast<void**>(ptr) - 1));
+			free(*(reinterpret_cast<void**>(ptr) - 1));
 	}
 };
 

--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -3505,7 +3505,7 @@ private:
 
 	// Fundamental alignment
 
-	template<typename U, typename std::enable_if<!(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename std::enable_if<!(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline U* create_array(size_t count)
 	{
 		assert(count > 0);
@@ -3520,7 +3520,7 @@ private:
 		return p;
 	}
 
-	template<typename U, typename std::enable_if<!(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename std::enable_if<!(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline void destroy_array(U* p, size_t count)
 	{
 		if (p != nullptr) {
@@ -3532,21 +3532,21 @@ private:
 		}
 	}
 
-	template<typename U, typename std::enable_if<!(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename std::enable_if<!(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline U* create()
 	{
 		auto p = (Traits::malloc)(sizeof(U));
 		return p != nullptr ? new (p) U : nullptr;
 	}
 
-	template<typename U, typename A1, typename std::enable_if<!(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename A1, typename std::enable_if<!(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline U* create(A1&& a1)
 	{
 		auto p = (Traits::malloc)(sizeof(U));
 		return p != nullptr ? new (p) U(std::forward<A1>(a1)) : nullptr;
 	}
 
-	template<typename U, typename std::enable_if<!(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename std::enable_if<!(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline void destroy(U* p)
 	{
 		if (p != nullptr) {
@@ -3557,7 +3557,7 @@ private:
 
 	// Extended alignment
 
-	template<typename U, typename std::enable_if<(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename std::enable_if<(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline U* create_array(size_t count)
 	{
 		assert(count > 0);
@@ -3572,7 +3572,7 @@ private:
 		return p;
 	}
 
-	template<typename U, typename std::enable_if<(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename std::enable_if<(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline void destroy_array(U* p, size_t count)
 	{
 		if (p != nullptr) {
@@ -3584,21 +3584,21 @@ private:
 		}
 	}
 
-	template<typename U, typename std::enable_if<(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename std::enable_if<(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline U* create()
 	{
 		auto p = (Traits::aligned_malloc)(sizeof(U), alignof(U));
 		return p != nullptr ? new (p) U : nullptr;
 	}
 
-	template<typename U, typename A1, typename std::enable_if<(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename A1, typename std::enable_if<(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline U* create(A1&& a1)
 	{
 		auto p = (Traits::aligned_malloc)(sizeof(U), alignof(U));
 		return p != nullptr ? new (p) U(std::forward<A1>(a1)) : nullptr;
 	}
 
-	template<typename U, typename std::enable_if<(alignof(U)>alignof(std::max_align_t)), int>::type = 0>
+	template<typename U, typename std::enable_if<(alignof(U)>alignof(details::max_align_t)), int>::type = 0>
 	static inline void destroy(U* p)
 	{
 		if (p != nullptr) {


### PR DESCRIPTION
This replaces the `static_assert` preventing super-aligned types from being used with one that prevents types with an alignment greater than their size from being used, sets `Block`'s alignment equal to `T`'s, adds `aligned_malloc` and `aligned_free` to `ConcurrentQueueDefaultTraits`, and adds specializations of `create`, `create_array`, `destroy`, and `destroy_array` for super-aligned types that use them.