### PR TITLE
Added CMake support.  Only tested on Linux (Ubuntu).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+# At the time of writing, using version 3.4.
+cmake_minimum_required(VERSION 3.4)
+
+
+# Enable ccache (if installed) :)
+find_program(CCACHE_PROGRAM ccache)
+if (CCACHE_PROGRAM)
+
+    message("NOTE: Using CCache for caching.")
+
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif ()
+
+project(moodycamel::ConcurrentQueue)
+
+message(STATUS "Project:    ${PROJECT_NAME}")
+message(STATUS "Platform:   ${CMAKE_SYSTEM_NAME} (${CMAKE_SYSTEM})")
+message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
+
+
+# Ensure C++11 support 
+set(CMAKE_CXX_STANDARD 11)
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic-errors -Wpedantic")
+
+else ()
+message(FATAL_ERROR "Unsupported platform!")
+endif ()
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+
+# Add moody-only headers
+include_directories(.)
+
+add_subdirectory(benchmarks)
+add_subdirectory(tests)
+
+# Install selected headers.
+install(FILES concurrentqueue.h blockingconcurrentqueue.h DESTINATION include/moodycamel)

--- a/README.md
+++ b/README.md
@@ -377,6 +377,29 @@ the object contains no internal pointers. Example:
 There are some more detailed samples [here][samples.md]. The source of
 the [unit tests][unittest-src] and [benchmarks][benchmark-src] are available for reference as well.
 
+## Buidling
+
+The code be built either using cmake or make files.
+
+### cmake
+
+    cd build
+    mkdir build.release && cd build.release
+    cmake -DCMAKE_BUILD_TYPE=RELEASE ..
+    make
+    
+Cmake build also has an optional install target.
+
+    make install
+    
+
+### make
+
+    cd build
+    make
+    
+No install target has been specified
+
 ## Benchmarks
 
 See my blog post for some [benchmark results][benchmarks] (including versus `boost::lockfree::queue` and `tbb::concurrent_queue`),

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ the [unit tests][unittest-src] and [benchmarks][benchmark-src] are available for
 
 ## Buidling
 
-The code be built either using cmake or make files.
+The code can be built either using cmake or make files.
 
 ### cmake
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,50 @@
+
+
+add_library(tbb STATIC
+    tbb/cache_aligned_allocator.cpp
+    tbb/concurrent_monitor.cpp
+    tbb/concurrent_queue.cpp
+    tbb/dynamic_link.cpp
+    tbb/tbb_misc.cpp)
+
+# Additional Include Directories
+target_include_directories(tbb PRIVATE
+    .
+    )
+
+target_compile_definitions(tbb PRIVATE
+    -D__TBB_BUILD=1
+    )
+
+set(TARGET_HPP
+    boostqueue.h
+    lockbasedqueue.h
+    simplelockfree.h
+    stdqueue.h
+    tbbqueue.h
+    wrappers.h
+    ../concurrentqueue.h
+    ../blockingconcurrentqueue.h
+    )
+
+set(TARGET_CPP
+    cpuid.cpp
+    benchmarks.cpp
+    ../tests/common/simplethread.cpp
+    ../tests/common/systemtime.cpp
+    )
+
+add_executable(benchmarks ${TARGET_HPP} ${TARGET_CPP})
+
+# Additional Include Directories
+target_include_directories(benchmarks PRIVATE
+    .
+    ../tests
+    ../tests/common
+    )
+
+target_link_libraries(benchmarks
+
+    tbb
+    pthread
+    )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+
+include_directories(common)
+
+add_subdirectory(fuzztests)
+add_subdirectory(unittests)

--- a/tests/fuzztests/CMakeLists.txt
+++ b/tests/fuzztests/CMakeLists.txt
@@ -1,0 +1,26 @@
+
+
+set(TARGET_HPP
+    ../corealgos.h
+    ../common/simplethread.h
+    ../common/systemtime.h
+    ../../concurrentqueue.h
+    ../../blockingconcurrentqueue.h
+    )
+
+set(TARGET_CPP
+    fuzztests.cpp
+    ../common/simplethread.cpp
+    ../common/systemtime.cpp
+    )
+
+add_executable(fuzztests ${TARGET_HPP} ${TARGET_CPP})
+
+# Additional Include Directories
+target_include_directories(fuzztests PUBLIC
+
+)
+
+target_link_libraries(fuzztests
+    pthread
+)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,0 +1,28 @@
+
+
+set(TARGET_HPP
+    minitest.h
+    ../corealgos.h
+    ../common/simplethread.h
+    ../common/systemtime.h
+    ../../concurrentqueue.h
+    ../../blockingconcurrentqueue.h
+    )
+
+set(TARGET_CPP
+    mallocmacro.cpp
+    unittests.cpp
+    ../common/simplethread.cpp
+    ../common/systemtime.cpp
+    )
+
+add_executable(unittests ${TARGET_HPP} ${TARGET_CPP})
+
+# Additional Include Directories
+target_include_directories(unittests PRIVATE
+
+    )
+
+target_link_libraries(unittests
+    pthread
+    )


### PR DESCRIPTION
Added cmake support.  Tested on Ubuntu Linux (17.04) using gcc.  Any other non-Linux platform or compiler variation will need a tiny bit of work to get it going.

In addition, cmake script now has a 'make install' target (which the current make targets don't have). On my system, concurrentqueue.h and blockingconcurrentqueue.h are installed to a directory in /usr/local/include/moodycamel.