### PR TITLE
Updated the `max_align_t` workaround to look for libstdc++ instead of GCC.

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -239,8 +239,8 @@ namespace details {
 			: static_cast<T>(-1);
 	};
 
-#if defined(__GNUC__) && !defined( __clang__ )
-	typedef ::max_align_t std_max_align_t;      // GCC forgot to add it to std:: for a while
+#if defined(__GLIBCXX__)
+	typedef ::max_align_t std_max_align_t;      // libstdc++ forgot to add it to std:: for a while
 #else
 	typedef std::max_align_t std_max_align_t;   // Others (e.g. MSVC) insist it can *only* be accessed via std::
 #endif


### PR DESCRIPTION
The `max_align_t` issue is in libstdc++ rather than GCC itself. This problem surfaces when
the library is used in clang / libstdc++ setup rather than clang / libc++. Here we simply check
for `__GLIBCXX__` rather than `__GNUC__`.