### PR TITLE
Fix infinite loop in blockingconcurrentqueue on OS X

### DIFF
--- a/blockingconcurrentqueue.h
+++ b/blockingconcurrentqueue.h
@@ -148,7 +148,7 @@ namespace details
 				// added in OSX 10.10: https://developer.apple.com/library/prerelease/mac/documentation/General/Reference/APIDiffsMacOSX10_10SeedDiff/modules/Darwin.html
 				kern_return_t rc = semaphore_timedwait(m_sema, ts);
 
-				return rc != KERN_OPERATION_TIMED_OUT;
+				return rc != KERN_OPERATION_TIMED_OUT && rc != KERN_ABORTED;
 			}
 
 			void signal()


### PR DESCRIPTION
Current code assumes that any value other than KERN_OPERATION_TIMED_OUT i
ndicates signal from another thread. 
This assumption is false, as other return values include interrupt,
e.g. from debugger.

This leads to infinite loop here: 
https://github.com/cameron314/concurrentqueue/blob/master/blockingconcurrentqueue.h#L817