### PR TITLE
Remove BOM from concurrentqueue.h

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -1,4 +1,4 @@
-﻿// Provides a C++11 implementation of a multi-producer, multi-consumer lock-free queue.
+// Provides a C++11 implementation of a multi-producer, multi-consumer lock-free queue.
 // An overview, including benchmark results, is provided here:
 //     http://moodycamel.com/blog/2014/a-fast-general-purpose-lock-free-queue-for-c++
 // The full design is also described in excruciating detail at:


### PR DESCRIPTION
For some reason the concurrentqueue.h file had a BOM file header and this prevent `#pragma once` to work correctly with gcc and precompiled headers (related issue is https://gcc.gnu.org/bugzilla/show_bug.cgi?format=multiple&id=56549), leading to obscure errors like
```
In file included from main.cpp:2:0:
/usr/include/concurrentqueue/concurrentqueue.h:49:40: error: redefinition of ‘struct moodycamel::details::thread_id_converter<thread_id_t>’
  template<typename thread_id_t> struct thread_id_converter {
                                        ^~~~~~~~~~~~~~~~~~~
In file included from pch.h:2:0:
/usr/include/concurrentqueue/concurrentqueue.h:49:40: note: previous definition of ‘struct moodycamel::details::thread_id_converter<thread_id_t>’
  template<typename thread_id_t> struct thread_id_converter {
```