### PR TITLE
Fixing check for address sanitizer

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -256,7 +256,7 @@ namespace moodycamel { namespace details {
 // we can apply per-function compile-time suppression.
 // See https://clang.llvm.org/docs/ThreadSanitizer.html#has-feature-thread-sanitizer
 #define MOODYCAMEL_NO_TSAN
-#if defined(__hasi_feature)
+#if defined(__has_feature)
  #if __has_feature(thread_sanitizer)
   #undef MOODYCAMEL_NO_TSAN
   #define MOODYCAMEL_NO_TSAN __attribute__((no_sanitize("thread")))

--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -255,10 +255,12 @@ namespace moodycamel { namespace details {
 // TSAN can false report races in lock-free code.  To enable TSAN to be used from projects that use this one,
 // we can apply per-function compile-time suppression.
 // See https://clang.llvm.org/docs/ThreadSanitizer.html#has-feature-thread-sanitizer
-#if defined(__has_feature) && __has_feature(thread_sanitizer)
-#define MOODYCAMEL_NO_TSAN __attribute__((no_sanitize("thread")))
-#else
 #define MOODYCAMEL_NO_TSAN
+#if defined(__hasi_feature)
+ #if __has_feature(thread_sanitizer)
+  #undef MOODYCAMEL_NO_TSAN
+  #define MOODYCAMEL_NO_TSAN __attribute__((no_sanitize("thread")))
+ #endif // TSAN
 #endif // TSAN
 
 // Compiler-specific likely/unlikely hints


### PR DESCRIPTION
Changing the preprocessor check for address sanitizer to match documented method, just like the fix for https://github.com/cameron314/readerwriterqueue/issues/69