### PR TITLE
Avoid locking in case the timeout is 0.

### DIFF
--- a/lightweightsemaphore.h
+++ b/lightweightsemaphore.h
@@ -206,6 +206,10 @@ public:
 
 	bool timed_wait(std::uint64_t usecs)
 	{
+		if (usecs == 0) {
+			return false;
+		}
+
 		struct timespec ts;
 		const int usecs_in_1_sec = 1000000;
 		const int nsecs_in_1_sec = 1000000000;


### PR DESCRIPTION
**Short summary**
When using light weight semaphore on linux with timeout 0, there is a sleep on a futex which makes the CPU idle. On windows and Mac if the timeout is 0 there is no sleep on a lock and the function returns immediately.
In my experiments the sleep on the futex with timeout 0 makes the pinned core 50% idle, this is a problem in case the thread has other tasks to perform.

**Long story:**
Consider that you have an event driven thread that gets events both from epoll API and the blocking concurrent queue. 
The thread first gets tasks from both the epoll and the queues and later on process them.
In order to avoid sleeping on the blocking concurrent queue, I'm using timeout 0 when calling to wait_dequeue_bulk_timed.
If there is no data the queue is sleeps on a sem_timedwait (I'm using linux). If no data is received from the queue the sem_timedwait is sleeping on futex. I saw in my test that the dedicated core is idle 50% of the time and as a result the thread does not handle the data from the epoll.

Thanks,
Asaf