### PR TITLE
Dpipe and minor C API fix

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -301,7 +301,7 @@ counter_t adjustForThreads(counter_t suggestedOps, int nthreads)
 }
 
 
-template<typename TQueue>
+template<typename TQueue, typename item_t>
 counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, unsigned int randSeed)
 {
 	switch (benchmark) {
@@ -312,9 +312,10 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 			std::uniform_int_distribution<int> rand(0, 20);
 			double total = 0;
 			SystemTime start;
+			item_t item = 1;
 			for (counter_t i = 0; i != ops; ++i) {
 				start = getSystemTime();
-				q.enqueue(i);
+				q.enqueue(item);
 				total += getTimeDelta(start);
 			}
 			return total;
@@ -325,9 +326,10 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 	case bench_mostly_enqueue: {
 		return adjustForThreads(rampUpToMeasurableNumberOfMaxOps([](counter_t ops) {
 			TQueue q;
+			item_t item = 1;
 			auto start = getSystemTime();
 			for (counter_t i = 0; i != ops; ++i) {
-				q.enqueue(i);
+				q.enqueue(item);
 			}
 			return getTimeDelta(start);
 		}), nthreads);
@@ -339,13 +341,14 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 	case bench_mpsc: {
 		return adjustForThreads(rampUpToMeasurableNumberOfMaxOps([](counter_t ops) {
 			TQueue q;
+			item_t item = 1;
 			for (counter_t i = 0; i != ops; ++i) {
-				q.enqueue(i);
+				q.enqueue(item);
 			}
-			int item;
+			item_t item_rec;
 			auto start = getSystemTime();
 			for (counter_t i = 0; i != ops; ++i) {
-				q.try_dequeue(item);
+				q.try_dequeue(item_rec);
 			}
 			return getTimeDelta(start);
 		}), nthreads);
@@ -353,7 +356,7 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 	case bench_only_enqueue_bulk:
 	case bench_only_enqueue_bulk_prealloc:
 	case bench_mostly_enqueue_bulk: {
-		std::vector<counter_t> data;
+		std::vector<item_t> data;
 		for (counter_t i = 0; i != BULK_BATCH_SIZE; ++i) {
 			data.push_back(i);
 		}
@@ -370,7 +373,7 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 	case bench_mostly_dequeue_bulk: {
 		return adjustForThreads(rampUpToMeasurableNumberOfMaxOps([](counter_t ops) {
 			TQueue q;
-			std::vector<int> data(BULK_BATCH_SIZE);
+			std::vector<item_t> data(BULK_BATCH_SIZE);
 			for (counter_t i = 0; i != ops; ++i) {
 				q.enqueue_bulk(data.cbegin(), data.size());
 			}
@@ -385,10 +388,10 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 	case bench_empty_dequeue: {
 		return adjustForThreads(rampUpToMeasurableNumberOfMaxOps([](counter_t ops) {
 			TQueue q;
-			int item;
+			item_t item_rec;
 			auto start = getSystemTime();
 			for (counter_t i = 0; i != ops; ++i) {
-				q.try_dequeue(item);
+				q.try_dequeue(item_rec);
 			}
 			return getTimeDelta(start);
 		}), nthreads);
@@ -396,11 +399,12 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 	case bench_enqueue_dequeue_pairs: {
 		return adjustForThreads(rampUpToMeasurableNumberOfMaxOps([](counter_t ops) {
 			TQueue q;
-			int item;
+			item_t item = 1;
+			item_t item_rec;
 			auto start = getSystemTime();
 			for (counter_t i = 0; i != ops; ++i) {
-				q.enqueue(i);
-				q.try_dequeue(item);
+				q.enqueue(item);
+				q.try_dequeue(item_rec);
 			}
 			return getTimeDelta(start);
 		}), nthreads);
@@ -409,11 +413,12 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 	case bench_heavy_concurrent: {
 		return adjustForThreads(rampUpToMeasurableNumberOfMaxOps([](counter_t ops) {
 			TQueue q;
-			int item;
+			item_t item=1;
+			item_t item_rec;
 			auto start = getSystemTime();
 			for (counter_t i = 0; i != ops; ++i) {
-				q.enqueue(i);
-				q.try_dequeue(item);
+				q.enqueue(item);
+				q.try_dequeue(item_rec);
 			}
 			return getTimeDelta(start);
 		}), nthreads);
@@ -427,7 +432,7 @@ counter_t determineMaxOpsForBenchmark(benchmark_type_t benchmark, int nthreads, 
 
 
 // Returns time elapsed, in (fractional) milliseconds
-template<typename TQueue>
+template<typename TQueue, typename item_t>
 double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, unsigned int randSeed, counter_t maxOps, int maxThreads, counter_t& out_opCount)
 {
 	double result = 0;
@@ -441,13 +446,14 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		std::vector<counter_t> ops(nthreads);
 		std::vector<double> times(nthreads);
 		std::atomic<int> ready(0);
+		item_t item_rec;
+		item_t item = 1;
 		for (int tid = 0; tid != nthreads; ++tid) {
 			threads[tid] = SimpleThread([&](int id) {
 				ready.fetch_add(1, std::memory_order_relaxed);
 				while (ready.load(std::memory_order_relaxed) != nthreads)
 					continue;
 				
-				int item;
 				SystemTime start;
 				RNG_t rng(randSeed * (id + 1));
 				std::uniform_int_distribution<int> rand(0, 20);
@@ -455,24 +461,25 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				times[id] = 0;
 				typename TQueue::consumer_token_t consTok(q);
 				typename TQueue::producer_token_t prodTok(q);
-			
+
+				
 				for (counter_t i = 0; i != maxOps; ++i) {
 					if (rand(rng) == 0) {
 						start = getSystemTime();
 						if ((i & 1) == 0) {
 							if (useTokens) {
-								q.try_dequeue(consTok, item);
+								q.try_dequeue(consTok, item_rec);
 							}
 							else {
-								q.try_dequeue(item);
+								q.try_dequeue(item_rec);
 							}
 						}
 						else {
 							if (useTokens) {
-								q.enqueue(prodTok, i);
+								q.enqueue(prodTok, item);
 							}
 							else {
-								q.enqueue(i);
+								q.enqueue(item);
 							}
 						}
 						times[id] += getTimeDelta(start);
@@ -488,8 +495,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			out_opCount += ops[tid];
 			result += times[tid];
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
@@ -497,23 +503,26 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		out_opCount = maxOps * nthreads;
 		
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		{
 			// Enqueue opcount elements first, then dequeue them; this
 			// will "stretch out" the queue, letting implementatations
 			// that re-use memory internally avoid having to allocate
 			// more later during the timed enqueue operations.
 			std::vector<SimpleThread> threads(nthreads);
+			
 			for (int tid = 0; tid != nthreads; ++tid) {
 				threads[tid] = SimpleThread([&](int id) {
 					if (useTokens) {
 						typename TQueue::producer_token_t tok(q);
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(tok, i);
+							q.enqueue(tok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(i);
+							q.enqueue(item);
 						}
 					}
 				}, tid);
@@ -523,8 +532,8 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			}
 			
 			// Now empty the queue
-			int item;
-			while (q.try_dequeue(item))
+			
+			while (q.try_dequeue(item_rec))
 				continue;
 		}
 		
@@ -534,12 +543,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			if (useTokens) {
 				typename TQueue::producer_token_t tok(q);
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.enqueue(tok, i);
+					q.enqueue(tok, item);
 				}
 			}
 			else {
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.enqueue(i);
+					q.enqueue(item);
 				}	
 			}
 			result = getTimeDelta(start);
@@ -558,12 +567,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					if (useTokens) {
 						typename TQueue::producer_token_t tok(q);
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(tok, i);
+							q.enqueue(tok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(i);
+							q.enqueue(item);
 						}
 					}
 					timings[id] = getTimeDelta(start);
@@ -575,8 +584,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				result += timings[tid];
 			}
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
@@ -584,18 +592,20 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		out_opCount = maxOps * nthreads;
 		
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		if (nthreads == 1) {
 			// No contention -- measures raw single-item enqueue speed
 			auto start = getSystemTime();
 			if (useTokens) {
 				typename TQueue::producer_token_t tok(q);
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.enqueue(tok, i);
+					q.enqueue(tok, item);
 				}
 			}
 			else {
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.enqueue(i);
+					q.enqueue(item);
 				}	
 			}
 			result = getTimeDelta(start);
@@ -614,12 +624,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					if (useTokens) {
 						typename TQueue::producer_token_t tok(q);
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(tok, i);
+							q.enqueue(tok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(i);
+							q.enqueue(item);
 						}
 					}
 					timings[id] = getTimeDelta(start);
@@ -631,8 +641,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				result += timings[tid];
 			}
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
@@ -641,6 +650,8 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		out_opCount = maxOps * nthreads;
 		
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		{
 			// Fill up the queue first
 			std::vector<SimpleThread> threads(benchmark == bench_spmc_preproduced ? 1 : nthreads);
@@ -650,12 +661,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					if (useTokens) {
 						typename TQueue::producer_token_t tok(q);
 						for (counter_t i = 0; i != itemsPerThread; ++i) {
-							q.enqueue(tok, i);
+							q.enqueue(tok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != itemsPerThread; ++i) {
-							q.enqueue(i);
+							q.enqueue(item);
 						}
 					}
 				}, tid);
@@ -667,17 +678,16 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		
 		if (nthreads == 1) {
 			// No contention -- measures raw single-item dequeue speed
-			int item;
 			auto start = getSystemTime();
 			if (useTokens) {
 				typename TQueue::consumer_token_t tok(q);
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.try_dequeue(tok, item);
+					q.try_dequeue(tok, item_rec);
 				}
 			}
 			else {
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.try_dequeue(item);
+					q.try_dequeue(item_rec);
 				}	
 			}
 			result = getTimeDelta(start);
@@ -692,17 +702,16 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					while (ready.load(std::memory_order_relaxed) != nthreads)
 						continue;
 					
-					int item;
 					auto start = getSystemTime();
 					if (useTokens) {
 						typename TQueue::consumer_token_t tok(q);
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.try_dequeue(tok, item);
+							q.try_dequeue(tok, item_rec);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.try_dequeue(item);
+							q.try_dequeue(item_rec);
 						}
 					}
 					timings[id] = getTimeDelta(start);
@@ -714,14 +723,15 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				result += timings[tid];
 			}
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_mostly_enqueue: {
 		// Measures the average operation speed when most threads are enqueueing
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		out_opCount = maxOps * nthreads;
 		std::vector<SimpleThread> threads(nthreads);
 		std::vector<double> timings(nthreads);
@@ -737,12 +747,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				if (useTokens) {
 					typename TQueue::producer_token_t tok(q);
 					for (counter_t i = 0; i != maxOps; ++i) {
-						q.enqueue(tok, i);
+						q.enqueue(tok, item);
 					}
 				}
 				else {
 					for (counter_t i = 0; i != maxOps; ++i) {
-						q.enqueue(i);
+						q.enqueue(item);
 					}
 				}
 				timings[id] = getTimeDelta(start);
@@ -754,17 +764,16 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				while (ready.load(std::memory_order_relaxed) != nthreads)
 					continue;
 				
-				int item;
 				auto start = getSystemTime();
 				if (useTokens) {
 					typename TQueue::consumer_token_t tok(q);
 					for (counter_t i = 0; i != maxOps; ++i) {
-						q.try_dequeue(tok, item);
+						q.try_dequeue(tok, item_rec);
 					}
 				}
 				else {
 					for (counter_t i = 0; i != maxOps; ++i) {
-						q.try_dequeue(item);
+						q.try_dequeue(item_rec);
 					}
 				}
 				timings[id] = getTimeDelta(start);
@@ -775,14 +784,15 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			threads[tid].join();
 			result += timings[tid];
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_mostly_dequeue: {
 		// Measures the average operation speed when most threads are dequeueing
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		out_opCount = maxOps * nthreads;
 		std::vector<SimpleThread> threads(nthreads);
 		std::vector<double> timings(nthreads);
@@ -795,12 +805,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					if (useTokens) {
 						typename TQueue::producer_token_t tok(q);
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(tok, i);
+							q.enqueue(tok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(i);
+							q.enqueue(item);
 						}
 					}
 				}, tid);
@@ -816,17 +826,16 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				while (ready.load(std::memory_order_relaxed) != nthreads)
 					continue;
 				
-				int item;
 				auto start = getSystemTime();
 				if (useTokens) {
 					typename TQueue::consumer_token_t tok(q);
 					for (counter_t i = 0; i != maxOps; ++i) {
-						q.try_dequeue(tok, item);
+						q.try_dequeue(tok, item_rec);
 					}
 				}
 				else {
 					for (counter_t i = 0; i != maxOps; ++i) {
-						q.try_dequeue(item);
+						q.try_dequeue(item_rec);
 					}
 				}
 				timings[id] = getTimeDelta(start);
@@ -842,12 +851,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				if (useTokens) {
 					typename TQueue::producer_token_t tok(q);
 					for (counter_t i = 0; i != maxOps; ++i) {
-						q.enqueue(tok, i);
+						q.enqueue(tok, item);
 					}
 				}
 				else {
 					for (counter_t i = 0; i != maxOps; ++i) {
-						q.enqueue(i);
+						q.enqueue(item);
 					}
 				}
 				timings[id] = getTimeDelta(start);
@@ -858,13 +867,14 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			threads[tid].join();
 			result += timings[tid];
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_only_enqueue_bulk_prealloc: {
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		{
 			// Enqueue opcount elements first, then dequeue them; this
 			// will "stretch out" the queue, letting implementatations
@@ -876,12 +886,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					if (useTokens) {
 						typename TQueue::producer_token_t tok(q);
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(tok, i);
+							q.enqueue(tok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(i);
+							q.enqueue(item);
 						}
 					}
 				}, tid);
@@ -891,8 +901,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			}
 			
 			// Now empty the queue
-			int item;
-			while (q.try_dequeue(item))
+			while (q.try_dequeue(item_rec))
 				continue;
 		}
 		
@@ -948,13 +957,14 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				result += timings[tid];
 			}
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_only_enqueue_bulk: {
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		std::vector<counter_t> data;
 		for (counter_t i = 0; i != BULK_BATCH_SIZE; ++i) {
 			data.push_back(i);
@@ -1007,14 +1017,15 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				result += timings[tid];
 			}
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_mostly_enqueue_bulk: {
 		// Measures the average speed of enqueueing in bulk under light contention
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		std::vector<counter_t> data;
 		for (counter_t i = 0; i != BULK_BATCH_SIZE; ++i) {
 			data.push_back(i);
@@ -1082,14 +1093,15 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				out_opCount += ops[tid];
 			}
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_only_dequeue_bulk: {
 		// Measures the average speed of dequeueing in bulk when all threads are consumers
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		{
 			// Fill up the queue first
 			std::vector<int> data(BULK_BATCH_SIZE);
@@ -1172,14 +1184,15 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				out_opCount += ops[tid];
 			}
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_mostly_dequeue_bulk: {
 		// Measures the average speed of dequeueing in bulk under light contention
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		auto enqueueThreads = std::max(1, nthreads / 4);
 		out_opCount = maxOps * BULK_BATCH_SIZE * enqueueThreads;
 		std::vector<SimpleThread> threads(nthreads);
@@ -1266,8 +1279,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				out_opCount += ops[tid];
 			}
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
@@ -1275,6 +1287,8 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		counter_t elementsToDequeue = maxOps * (nthreads - 1);
 		
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		std::vector<SimpleThread> threads(nthreads - 1);
 		std::vector<double> timings(nthreads - 1);
 		std::vector<counter_t> ops(nthreads - 1);
@@ -1303,7 +1317,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				}
 				else {
 					while (true) {
-						if (q.try_dequeue(item)) {
+						if (q.try_dequeue(item_rec)) {
 							totalDequeued.fetch_add(1, std::memory_order_relaxed);
 						}
 						else if (totalDequeued.load(std::memory_order_relaxed) == elementsToDequeue) {
@@ -1319,7 +1333,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		
 		lynchpin.store(true, std::memory_order_seq_cst);
 		for (counter_t i = 0; i != elementsToDequeue; ++i) {
-			q.enqueue(i);
+			q.enqueue(item);
 		}
 		
 		result = 0;
@@ -1329,13 +1343,14 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			result += timings[tid];
 			out_opCount += ops[tid];
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_mpsc: {
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		counter_t elementsToDequeue = maxOps * (nthreads - 1);
 		std::vector<SimpleThread> threads(nthreads);
 		std::atomic<int> ready(0);
@@ -1359,7 +1374,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					}
 					else {
 						for (counter_t i = 0; i != elementsToDequeue;) {
-							i += q.try_dequeue(item) ? 1 : 0;
+							i += q.try_dequeue(item_rec) ? 1 : 0;
 							++out_opCount;
 						}
 					}
@@ -1375,12 +1390,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					if (useTokens) {
 						typename TQueue::producer_token_t tok(q);
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(tok, i);
+							q.enqueue(tok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(i);
+							q.enqueue(item);
 						}
 					}
 				}, tid);
@@ -1390,14 +1405,15 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		for (int tid = 0; tid != nthreads; ++tid) {
 			threads[tid].join();
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
 	case bench_empty_dequeue: {
 		// Measures the average speed of attempting to dequeue from an empty queue
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		// Fill up then empty the queue first
 		{
 			std::vector<SimpleThread> threads(maxThreads > 0 ? maxThreads : 8);
@@ -1406,12 +1422,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					if (useTokens) {
 						typename TQueue::producer_token_t tok(q);
 						for (counter_t i = 0; i != 10000; ++i) {
-							q.enqueue(tok, i);
+							q.enqueue(tok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != 10000; ++i) {
-							q.enqueue(i);
+							q.enqueue(item);
 						}
 					}
 				}, tid);
@@ -1421,8 +1437,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			}
 			
 			// Empty the queue
-			int item;
-			while (q.try_dequeue(item))
+			while (q.try_dequeue(item_rec))
 				continue;
 		}
 		
@@ -1439,11 +1454,11 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			}
 			else {
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.try_dequeue(item);
+					q.try_dequeue(item_rec);
 				}
 			}
 			result = getTimeDelta(start);
-			forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+			forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		}
 		else {
 			out_opCount = maxOps * nthreads;
@@ -1466,7 +1481,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.try_dequeue(item);
+							q.try_dequeue(item_rec);
 						}
 					}
 					timings[id] = getTimeDelta(start);
@@ -1477,8 +1492,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				threads[tid].join();
 				result += timings[tid];
 			}
-			int item;
-			forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+			forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		}
 		break;
 	}
@@ -1488,26 +1502,28 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		// (that eight separate threads had at one point enqueued to)
 		out_opCount = maxOps * 2 * nthreads;
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		if (nthreads == 1) {
 			// No contention -- measures speed of immediately dequeueing the item that was just enqueued
 			int item;
 			auto start = getSystemTime();
 			if (useTokens) {
-				typename TQueue::producer_token_t ptok(q);
-				typename TQueue::consumer_token_t ctok(q);
+				typename TQueue::producer_token_t prodTok(q);
+				typename TQueue::consumer_token_t consTok(q);
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.enqueue(ptok, i);
-					q.try_dequeue(ctok, item);
+					q.enqueue(prodTok, item);
+					q.try_dequeue(consTok, item);
 				}
 			}
 			else {
 				for (counter_t i = 0; i != maxOps; ++i) {
-					q.enqueue(i);
-					q.try_dequeue(item);
+					q.enqueue(item);
+					q.try_dequeue(item_rec);
 				}
 			}
 			result = getTimeDelta(start);
-			forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+			forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		}
 		else {
 			std::vector<SimpleThread> threads(nthreads);
@@ -1522,17 +1538,17 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 					int item;
 					auto start = getSystemTime();
 					if (useTokens) {
-						typename TQueue::producer_token_t ptok(q);
-						typename TQueue::consumer_token_t ctok(q);
+						typename TQueue::producer_token_t prodTok(q);
+						typename TQueue::consumer_token_t consTok(q);
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(ptok, i);
-							q.try_dequeue(ctok, item);
+							q.enqueue(prodTok, item);
+							q.try_dequeue(consTok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps; ++i) {
-							q.enqueue(i);
-							q.try_dequeue(item);
+							q.enqueue(item);
+							q.try_dequeue(item_rec);
 						}
 					}
 					timings[id] = getTimeDelta(start);
@@ -1543,8 +1559,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 				threads[tid].join();
 				result += timings[tid];
 			}
-			int item;
-			forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+			forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		}
 		break;
 	}
@@ -1553,6 +1568,8 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 		// Measures the average operation speed with many threads under heavy load
 		out_opCount = maxOps * nthreads;
 		TQueue q;
+		item_t item = 1;
+		item_t item_rec;
 		std::vector<SimpleThread> threads(nthreads);
 		std::vector<double> timings(nthreads);
 		std::atomic<int> ready(0);
@@ -1572,13 +1589,13 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 						
 						for (counter_t i = 0; i != maxOps / 2; ++i) {
 							q.try_dequeue(consTok, item);
-							q.enqueue(prodTok, i);
+							q.enqueue(prodTok, item);
 						}
 					}
 					else {
 						for (counter_t i = 0; i != maxOps / 2; ++i) {
-							q.try_dequeue(item);
-							q.enqueue(i);
+							q.try_dequeue(item_rec);
+							q.enqueue(item);
 						}
 					}
 				}
@@ -1588,12 +1605,12 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 						if (useTokens) {
 							typename TQueue::producer_token_t prodTok(q);
 							for (counter_t i = 0; i != maxOps; ++i) {
-								q.enqueue(prodTok, i);
+								q.enqueue(prodTok, item);
 							}
 						}
 						else {
 							for (counter_t i = 0; i != maxOps; ++i) {
-								q.enqueue(i);
+								q.enqueue(item);
 							}
 						}
 					}
@@ -1608,7 +1625,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 						}
 						else {
 							for (counter_t i = 0; i != maxOps; ++i) {
-								q.try_dequeue(item);
+								q.try_dequeue(item_rec);
 							}
 						}
 					}
@@ -1621,8 +1638,7 @@ double runBenchmark(benchmark_type_t benchmark, int nthreads, bool useTokens, un
 			threads[tid].join();
 			result += timings[tid];
 		}
-		int item;
-		forceNoOptimizeDummy = q.try_dequeue(item) ? 1 : 0;
+		forceNoOptimizeDummy = q.try_dequeue(item_rec) ? 1 : 0;
 		break;
 	}
 	
@@ -1970,28 +1986,28 @@ int main(int argc, char** argv)
 					counter_t maxOps;
 					switch ((queue_id_t)queue) {
 					case queue_moodycamel_ConcurrentQueue:
-						maxOps = determineMaxOpsForBenchmark<moodycamel::ConcurrentQueue<int, Traits>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
+						maxOps = determineMaxOpsForBenchmark<moodycamel::ConcurrentQueue<int, Traits>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
 						break;
 					case queue_moodycamel_BlockingConcurrentQueue:
-						maxOps = determineMaxOpsForBenchmark<moodycamel::BlockingConcurrentQueue<int, Traits>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
+						maxOps = determineMaxOpsForBenchmark<moodycamel::BlockingConcurrentQueue<int, Traits>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
 						break;
 					case queue_lockbased:
-						maxOps = determineMaxOpsForBenchmark<LockBasedQueue<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
+						maxOps = determineMaxOpsForBenchmark<LockBasedQueue<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
 						break;
 					case queue_simplelockfree:
-						maxOps = determineMaxOpsForBenchmark<SimpleLockFreeQueue<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
+						maxOps = determineMaxOpsForBenchmark<SimpleLockFreeQueue<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
 						break;
 					case queue_boost:
-						maxOps = determineMaxOpsForBenchmark<BoostQueueWrapper<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
+						maxOps = determineMaxOpsForBenchmark<BoostQueueWrapper<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
 						break;
 					case queue_tbb:
-						maxOps = determineMaxOpsForBenchmark<TbbQueueWrapper<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
+						maxOps = determineMaxOpsForBenchmark<TbbQueueWrapper<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
 						break;
 					case queue_std:
-						maxOps = determineMaxOpsForBenchmark<StdQueueWrapper<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
+						maxOps = determineMaxOpsForBenchmark<StdQueueWrapper<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
 						break;
 					case queue_dlib:
-						maxOps = determineMaxOpsForBenchmark<DlibQueueWrapper<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
+						maxOps = determineMaxOpsForBenchmark<DlibQueueWrapper<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed);
 						break;
 					default:
 						assert(false && "There should be a case here for every queue in the benchmarks!");
@@ -2006,28 +2022,28 @@ int main(int argc, char** argv)
 						
 						switch ((queue_id_t)queue) {
 						case queue_moodycamel_ConcurrentQueue:
-							elapsed = runBenchmark<moodycamel::ConcurrentQueue<int, Traits>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
+							elapsed = runBenchmark<moodycamel::ConcurrentQueue<int, Traits>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
 							break;
 						case queue_moodycamel_BlockingConcurrentQueue:
-							elapsed = runBenchmark<moodycamel::BlockingConcurrentQueue<int, Traits>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
+							elapsed = runBenchmark<moodycamel::BlockingConcurrentQueue<int, Traits>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
 							break;
 						case queue_lockbased:
-							elapsed = runBenchmark<LockBasedQueue<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
+							elapsed = runBenchmark<LockBasedQueue<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
 							break;
 						case queue_simplelockfree:
-							elapsed = runBenchmark<SimpleLockFreeQueue<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
+							elapsed = runBenchmark<SimpleLockFreeQueue<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
 							break;
 						case queue_boost:
-							elapsed = runBenchmark<BoostQueueWrapper<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
+							elapsed = runBenchmark<BoostQueueWrapper<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
 							break;
 						case queue_tbb:
-							elapsed = runBenchmark<TbbQueueWrapper<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
+							elapsed = runBenchmark<TbbQueueWrapper<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
 							break;
 						case queue_std:
-							elapsed = runBenchmark<StdQueueWrapper<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
+							elapsed = runBenchmark<StdQueueWrapper<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
 							break;
 						case queue_dlib:
-							elapsed = runBenchmark<DlibQueueWrapper<int>>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
+							elapsed = runBenchmark<DlibQueueWrapper<int>, int>((benchmark_type_t)benchmark, nthreads, (bool)useTokens, seed, maxOps, maxThreads, ops);
 							break;
 						default:
 							assert(false && "There should be a case here for every queue in the benchmarks!");

--- a/benchmarks/dlib/config.h
+++ b/benchmarks/dlib/config.h
@@ -7,7 +7,7 @@
 // always off.  If you don't define one of these two macros then DLIB_ASSERT will toggle
 // automatically depending on the state of certain other macros, which is not what you want
 // when creating a shared library.
-#define ENABLE_ASSERTS       // asserts always enabled 
+// #define ENABLE_ASSERTS       // asserts always enabled 
 /* #undef DLIB_DISABLE_ASSERTS */
 
 /* #undef DLIB_ISO_CPP_ONLY */
@@ -30,5 +30,5 @@
 
 // This variable allows dlib/test_for_odr_violations.h to catch people who mistakenly use
 // headers from one version of dlib with a compiled dlib binary from a different dlib version.
-#define DLIB_CHECK_FOR_VERSION_MISMATCH DLIB_VERSION_MISMATCH_CHECK__EXPECTED_VERSION_19_21_99
+// #define DLIB_CHECK_FOR_VERSION_MISMATCH DLIB_VERSION_MISMATCH_CHECK__EXPECTED_VERSION_19_21_99
 

--- a/benchmarks/dlib/test_for_odr_violations.h
+++ b/benchmarks/dlib/test_for_odr_violations.h
@@ -19,9 +19,6 @@ extern "C"
 #ifdef ENABLE_ASSERTS
     const extern int USER_ERROR__inconsistent_build_configuration__see_dlib_faq_1;
     const int DLIB_NO_WARN_UNUSED dlib_check_assert_helper_variable = USER_ERROR__inconsistent_build_configuration__see_dlib_faq_1;
-#else
-    const extern int USER_ERROR__inconsistent_build_configuration__see_dlib_faq_1_;
-    const int DLIB_NO_WARN_UNUSED dlib_check_assert_helper_variable = USER_ERROR__inconsistent_build_configuration__see_dlib_faq_1_;
 #endif
 
 

--- a/c_api/concurrentqueue.h
+++ b/c_api/concurrentqueue.h
@@ -14,6 +14,8 @@ extern "C" {
 #define MOODYCAMEL_EXPORT __declspec(dllimport)
 #endif
 #endif
+#else
+#define MOODYCAMEL_EXPORT
 #endif
 
 typedef void* MoodycamelCQHandle;


### PR DESCRIPTION
First, in C API for non-win platform some macro was not defined

Second, benchmark didn't compile for two very different reasons.
First reason: some missed symbols, mostly because dlib is a compiled library with extensive checks for versioning and ODR across multiple compilation units. Luckily, that's fixed with its config and one minor bugfix.

Second, the most important: dpipe has no API for copy to queue, only exchange. And that means, you can't exchange counter_t values with int values. And you can't replace all `int`s with `counter_t` for `i` either, because exchange will replace it's value. So, fast way is to copy to some temp and then enqueue it. But that means double copy for every other queues, not good. And special benchmark for that is not good either. So, I changed benchmarks templates to send item_t (int in our case) and created `item_t item =1` outside of loops to enqueue that.

At least now MSVC compiled it without complains.