### PR TITLE
adding wards for Intel compiler

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
 // Disable -Wconversion warnings (spuriously triggered when Traits::size_t and
 // Traits::index_t are set to < 32 bits, causing integer promotion, causing warnings
 // upon assigning any computed values)
@@ -3737,6 +3737,6 @@ inline void swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a, ty
 #pragma warning(pop)
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Currently it is not possible to compile with Intel when warnings are turned into errors (`-Werror-all`):

~~~
concurrentqueue.h(38): error #2282: unrecognized GCC pragma
  #pragma GCC diagnostic push
                         ^

concurrentqueue.h(39): error #2282: unrecognized GCC pragma
  #pragma GCC diagnostic ignored "-Wconversion"
                         ^

concurrentqueue.h(3741): error #2282: unrecognized GCC pragma
  #pragma GCC diagnostic pop
~~~

this PR fixes this