### PR TITLE
Make is_lock_free constexpr.

### DIFF
--- a/blockingconcurrentqueue.h
+++ b/blockingconcurrentqueue.h
@@ -544,7 +544,7 @@ public:
 	// Returns true if the underlying atomic variables used by
 	// the queue are lock-free (they should be on most platforms).
 	// Thread-safe.
-	static bool is_lock_free()
+	static constexpr bool is_lock_free()
 	{
 		return ConcurrentQueue::is_lock_free();
 	}

--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -1314,7 +1314,7 @@ public:
 	// Returns true if the underlying atomic variables used by
 	// the queue are lock-free (they should be on most platforms).
 	// Thread-safe.
-	static bool is_lock_free()
+	static constexpr bool is_lock_free()
 	{
 		return
 			details::static_is_lock_free<bool>::value == 2 &&

--- a/tests/unittests/unittests.cpp
+++ b/tests/unittests/unittests.cpp
@@ -3643,9 +3643,9 @@ public:
 		
 		// is_lock_free()
 		{
-			bool lockFree = ConcurrentQueue<Foo, Traits>::is_lock_free();
+			constexpr bool lockFree = ConcurrentQueue<Foo, Traits>::is_lock_free();
 #if defined(__amd64__) || defined(_M_X64) || defined(__x86_64__) || defined(_M_IX86) || defined(__i386__) || defined(_M_PPC) || defined(__powerpc__)
-			ASSERT_OR_FAIL(lockFree);
+			static_assert(lockFree, "is_lock_free should be true");
 #else
 			(void)lockFree;
 #endif


### PR DESCRIPTION
This makes it possible to use it in `static_assert`, which is better
than a runtime error.