### PR TITLE
Replace BLOCK_SIZE with CQ_BLOCK_SIZE 

### DIFF
--- a/blockingconcurrentqueue.h
+++ b/blockingconcurrentqueue.h
@@ -36,7 +36,7 @@ public:
 	typedef typename ConcurrentQueue::size_t size_t;
 	typedef typename std::make_signed<size_t>::type ssize_t;
 	
-	static const size_t BLOCK_SIZE = ConcurrentQueue::BLOCK_SIZE;
+	static const size_t CQ_BLOCK_SIZE = ConcurrentQueue::CQ_BLOCK_SIZE;
 	static const size_t EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD = ConcurrentQueue::EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD;
 	static const size_t EXPLICIT_INITIAL_INDEX_SIZE = ConcurrentQueue::EXPLICIT_INITIAL_INDEX_SIZE;
 	static const size_t IMPLICIT_INITIAL_INDEX_SIZE = ConcurrentQueue::IMPLICIT_INITIAL_INDEX_SIZE;
@@ -55,7 +55,7 @@ public:
 	// queue is fully constructed before it starts being used by other threads (this
 	// includes making the memory effects of construction visible, possibly with a
 	// memory barrier).
-	explicit BlockingConcurrentQueue(size_t capacity = 6 * BLOCK_SIZE)
+	explicit BlockingConcurrentQueue(size_t capacity = 6 * CQ_BLOCK_SIZE)
 		: inner(capacity), sema(create<LightweightSemaphore, ssize_t, int>(0, (int)Traits::MAX_SEMA_SPINS), &BlockingConcurrentQueue::template destroy<LightweightSemaphore>)
 	{
 		assert(reinterpret_cast<ConcurrentQueue*>((BlockingConcurrentQueue*)1) == &((BlockingConcurrentQueue*)1)->inner && "BlockingConcurrentQueue must have ConcurrentQueue as its first member");

--- a/tests/unittests/unittests.cpp
+++ b/tests/unittests/unittests.cpp
@@ -96,13 +96,13 @@ struct MallocTrackingTraits : public ConcurrentQueueDefaultTraits
 	static inline void free(void* ptr) { tracking_allocator::free(ptr); }
 };
 
-template<std::size_t BlockSize = ConcurrentQueueDefaultTraits::BLOCK_SIZE, std::size_t InitialIndexSize = ConcurrentQueueDefaultTraits::EXPLICIT_INITIAL_INDEX_SIZE, bool RecycleBlocks = ConcurrentQueueDefaultTraits::RECYCLE_ALLOCATED_BLOCKS>
+template<std::size_t BlockSize = ConcurrentQueueDefaultTraits::CQ_BLOCK_SIZE, std::size_t InitialIndexSize = ConcurrentQueueDefaultTraits::EXPLICIT_INITIAL_INDEX_SIZE, bool RecycleBlocks = ConcurrentQueueDefaultTraits::RECYCLE_ALLOCATED_BLOCKS>
 struct TestTraits : public MallocTrackingTraits
 {
 	typedef std::size_t size_t;
 	typedef uint64_t index_t;
 	
-	static const size_t BLOCK_SIZE = BlockSize;
+	static const size_t CQ_BLOCK_SIZE = BlockSize;
 	static const size_t EXPLICIT_INITIAL_INDEX_SIZE = InitialIndexSize;
 	static const size_t IMPLICIT_INITIAL_INDEX_SIZE = InitialIndexSize * 2;
 	static const bool RECYCLE_ALLOCATED_BLOCKS = RecycleBlocks;
@@ -131,7 +131,7 @@ struct ExtraSmallIndexTraits : public MallocTrackingTraits
 
 struct LargeTraits : public MallocTrackingTraits
 {
-	static const size_t BLOCK_SIZE = 128;
+	static const size_t CQ_BLOCK_SIZE = 128;
 	static const size_t INITIAL_IMPLICIT_PRODUCER_HASH_SIZE = 128;
 	static const size_t IMPLICIT_INITIAL_INDEX_SIZE = 128;
 };
@@ -1354,7 +1354,7 @@ public:
 		{
 			// Implicit
 			const int MAX_THREADS = 48;
-			ConcurrentQueue<int, Traits> q(Traits::BLOCK_SIZE * (MAX_THREADS + 1));
+			ConcurrentQueue<int, Traits> q(Traits::CQ_BLOCK_SIZE * (MAX_THREADS + 1));
 			ASSERT_OR_FAIL(Traits::malloc_count() == 1);		// Initial block pool
 			
 			SimpleThread t0([&]() { q.enqueue(0); });
@@ -2392,7 +2392,7 @@ public:
 	
 	struct SizeLimitTraits : public MallocTrackingTraits
 	{
-		static const size_t BLOCK_SIZE = 2;
+		static const size_t CQ_BLOCK_SIZE = 2;
 		static const size_t MAX_SUBQUEUE_SIZE = 5;		// Will round up to 6 because of block size
 	};
 	


### PR DESCRIPTION
As Linux defines as a C macro it in <sys/mount.h>.

So, as much as I think that Linux shouldn't define such generic-sounding macro... I don't think it'd be an easy change to get accepted upstream, but it leads to errors if for some reason <sys/mount.h> gets included before concurrentqueue, thus it's likely safer to prefix the variable name here. CQ_BLOCK_SIZE yields no matches in my /usr/include so less likely to conflict
 
