### PR TITLE
Make cmake ARCH_INDEPENDENT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ write_basic_package_version_file(
     VERSION 
         ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
+    ARCH_INDEPENDENT
 )
 
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in


### PR DESCRIPTION
Hi

Just tripped over a weird issue using Fedora's concurrentqueue package. Its generated `concurrentqueueConfigVersion.cmake` has this at the end:

```
# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "4" STREQUAL "")
  return()
endif()

# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "4")
  math(EXPR installedBits "4 * 8")
  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
  set(PACKAGE_VERSION_UNSUITABLE TRUE)
endif()
```

which causes `meson` to fail to find the package using its `cmake` dependency finder, as `CMAKE_SIZEOF_VOID_P` is 8.

To remove that chunk of cmake completely, it looks like adding `ARCH_INDEPENDENT` to `write_basic_package_version_file` is the thing to do. Certainly regenerating the Fedora package with this patch removes the above and allows meson to find the package, but I avoid cmake at all costs (` OR "4" STREQUAL ""`?!) so wouldn't like to say it's the best approach...

Thanks

PS also noticed the version isn't updated at the top of the CMakeLists.txt.