### PR TITLE
Updated SALSA article URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,4 +530,4 @@ of the queue itself, followed lastly by the free-standing swap functions.
 [cdschecker]: http://demsky.eecs.uci.edu/c11modelchecker.html
 [relacy]: http://www.1024cores.net/home/relacy-race-detector
 [spsc]: https://github.com/cameron314/readerwriterqueue
-[salsa]: http://webee.technion.ac.il/~idish/ftp/spaa049-gidron.pdf
+[salsa]: https://iditkeidar.com/wp-content/uploads/files/ftp/spaa049-gidron.pdf


### PR DESCRIPTION
The previous one doesn't work anymore
There is also a [full version](https://iditkeidar.com/wp-content/uploads/files/ftp/SALSA-full.pdf)
and a slitly modified version of the full verion is also available via [Technion hosting](https://ece.technion.ac.il/wp-content/uploads/2021/01/publication_807-1.pdf)

Also, maybe web archive links should be considered