### PR TITLE
feature/disable ubsan warnings

### DIFF
--- a/blockingconcurrentqueue.h
+++ b/blockingconcurrentqueue.h
@@ -36,7 +36,7 @@ public:
 	typedef typename ConcurrentQueue::size_t size_t;
 	typedef typename std::make_signed<size_t>::type ssize_t;
 	
-	static const size_t BLOCK_SIZE = ConcurrentQueue::BLOCK_SIZE;
+	static const size_t CQ_BLOCK_SIZE = ConcurrentQueue::CQ_BLOCK_SIZE;
 	static const size_t EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD = ConcurrentQueue::EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD;
 	static const size_t EXPLICIT_INITIAL_INDEX_SIZE = ConcurrentQueue::EXPLICIT_INITIAL_INDEX_SIZE;
 	static const size_t IMPLICIT_INITIAL_INDEX_SIZE = ConcurrentQueue::IMPLICIT_INITIAL_INDEX_SIZE;
@@ -55,7 +55,7 @@ public:
 	// queue is fully constructed before it starts being used by other threads (this
 	// includes making the memory effects of construction visible, possibly with a
 	// memory barrier).
-	explicit BlockingConcurrentQueue(size_t capacity = 6 * BLOCK_SIZE)
+	explicit BlockingConcurrentQueue(size_t capacity = 6 * CQ_BLOCK_SIZE)
 		: inner(capacity), sema(create<LightweightSemaphore, ssize_t, int>(0, (int)Traits::MAX_SEMA_SPINS), &BlockingConcurrentQueue::template destroy<LightweightSemaphore>)
 	{
 		assert(reinterpret_cast<ConcurrentQueue*>((BlockingConcurrentQueue*)1) == &((BlockingConcurrentQueue*)1)->inner && "BlockingConcurrentQueue must have ConcurrentQueue as its first member");

--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -466,7 +466,7 @@ namespace details
 	};
 	template<std::size_t size> struct hash_32_or_64 : public _hash_32_or_64<(size > 4)> {  };
 	
-	static inline size_t hash_thread_id(thread_id_t id)
+	inline size_t hash_thread_id(thread_id_t id)
 	{
 		static_assert(sizeof(thread_id_t) <= 8, "Expected a platform where thread IDs are at most 64-bit values");
 		return static_cast<size_t>(hash_32_or_64<sizeof(thread_id_converter<thread_id_t>::thread_id_hash_t)>::hash(
@@ -474,7 +474,7 @@ namespace details
 	}
 	
 	template<typename T>
-	static inline bool circular_less_than(T a, T b)
+	inline bool circular_less_than(T a, T b)
 	{
 		static_assert(std::is_integral<T>::value && !std::numeric_limits<T>::is_signed, "circular_less_than is intended to be used only with unsigned integer types");
 		return static_cast<T>(a - b) > static_cast<T>(static_cast<T>(1) << (static_cast<T>(sizeof(T) * CHAR_BIT - 1)));
@@ -483,14 +483,14 @@ namespace details
 	}
 	
 	template<typename U>
-	static inline char* align_for(char* ptr)
+	inline char* align_for(char* ptr)
 	{
 		const std::size_t alignment = std::alignment_of<U>::value;
 		return ptr + (alignment - (reinterpret_cast<std::uintptr_t>(ptr) % alignment)) % alignment;
 	}
 
 	template<typename T>
-	static inline T ceil_to_pow_2(T x)
+	inline T ceil_to_pow_2(T x)
 	{
 		static_assert(std::is_integral<T>::value && !std::numeric_limits<T>::is_signed, "ceil_to_pow_2 is intended to be used only with unsigned integer types");
 
@@ -507,7 +507,7 @@ namespace details
 	}
 	
 	template<typename T>
-	static inline void swap_relaxed(std::atomic<T>& left, std::atomic<T>& right)
+	inline void swap_relaxed(std::atomic<T>& left, std::atomic<T>& right)
 	{
 		T temp = std::move(left.load(std::memory_order_relaxed));
 		left.store(std::move(right.load(std::memory_order_relaxed)), std::memory_order_relaxed);
@@ -515,7 +515,7 @@ namespace details
 	}
 	
 	template<typename T>
-	static inline T const& nomove(T const& x)
+	inline T const& nomove(T const& x)
 	{
 		return x;
 	}
@@ -542,7 +542,7 @@ namespace details
 	};
 	
 	template<typename It>
-	static inline auto deref_noexcept(It& it) MOODYCAMEL_NOEXCEPT -> decltype(*it)
+	inline auto deref_noexcept(It& it) MOODYCAMEL_NOEXCEPT -> decltype(*it)
 	{
 		return *it;
 	}

--- a/tests/unittests/unittests.cpp
+++ b/tests/unittests/unittests.cpp
@@ -96,13 +96,13 @@ struct MallocTrackingTraits : public ConcurrentQueueDefaultTraits
 	static inline void free(void* ptr) { tracking_allocator::free(ptr); }
 };
 
-template<std::size_t BlockSize = ConcurrentQueueDefaultTraits::BLOCK_SIZE, std::size_t InitialIndexSize = ConcurrentQueueDefaultTraits::EXPLICIT_INITIAL_INDEX_SIZE, bool RecycleBlocks = ConcurrentQueueDefaultTraits::RECYCLE_ALLOCATED_BLOCKS>
+template<std::size_t BlockSize = ConcurrentQueueDefaultTraits::CQ_BLOCK_SIZE, std::size_t InitialIndexSize = ConcurrentQueueDefaultTraits::EXPLICIT_INITIAL_INDEX_SIZE, bool RecycleBlocks = ConcurrentQueueDefaultTraits::RECYCLE_ALLOCATED_BLOCKS>
 struct TestTraits : public MallocTrackingTraits
 {
 	typedef std::size_t size_t;
 	typedef uint64_t index_t;
 	
-	static const size_t BLOCK_SIZE = BlockSize;
+	static const size_t CQ_BLOCK_SIZE = BlockSize;
 	static const size_t EXPLICIT_INITIAL_INDEX_SIZE = InitialIndexSize;
 	static const size_t IMPLICIT_INITIAL_INDEX_SIZE = InitialIndexSize * 2;
 	static const bool RECYCLE_ALLOCATED_BLOCKS = RecycleBlocks;
@@ -131,7 +131,7 @@ struct ExtraSmallIndexTraits : public MallocTrackingTraits
 
 struct LargeTraits : public MallocTrackingTraits
 {
-	static const size_t BLOCK_SIZE = 128;
+	static const size_t CQ_BLOCK_SIZE = 128;
 	static const size_t INITIAL_IMPLICIT_PRODUCER_HASH_SIZE = 128;
 	static const size_t IMPLICIT_INITIAL_INDEX_SIZE = 128;
 };
@@ -1354,7 +1354,7 @@ public:
 		{
 			// Implicit
 			const int MAX_THREADS = 48;
-			ConcurrentQueue<int, Traits> q(Traits::BLOCK_SIZE * (MAX_THREADS + 1));
+			ConcurrentQueue<int, Traits> q(Traits::CQ_BLOCK_SIZE * (MAX_THREADS + 1));
 			ASSERT_OR_FAIL(Traits::malloc_count() == 1);		// Initial block pool
 			
 			SimpleThread t0([&]() { q.enqueue(0); });
@@ -2392,7 +2392,7 @@ public:
 	
 	struct SizeLimitTraits : public MallocTrackingTraits
 	{
-		static const size_t BLOCK_SIZE = 2;
+		static const size_t CQ_BLOCK_SIZE = 2;
 		static const size_t MAX_SUBQUEUE_SIZE = 5;		// Will round up to 6 because of block size
 	};
 	


### PR DESCRIPTION
- **Update concurrentqueue.h**
- **Update lightweightsemaphore.h**
- **Update lightweightsemaphore.h**
- **Update lightweightsemaphore.h**
- **Replace BLOCK_SIZE with CQ_BLOCK_SIZE to avoid conflicts with <sys/mount.h>**
- **Improve compatibility with c++ modules**
- **Disable ubsan's integer sanitizer warnings**
