### PR TITLE
Place upper bound on required CMake version to avoid deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.9)
+# See https://discourse.cmake.org/t/how-to-fix-cmake-minimum-required-deprecation-warning/2487/2
+# for more on setting the minimum required version.
+
+cmake_minimum_required(VERSION 3.9...3.31.7)
 project(concurrentqueue VERSION 1.0.0)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Fix CMake deprecation warning.

Replicates [this fix](https://github.com/cameron314/readerwriterqueue/commit/3f4f80f4efb840a4483f1b80869d61811f9e8398) that was applied to [readerwriterqueue](https://github.com/cameron314/readerwriterqueue) but not here.