### PR TITLE
Add native and RISC-V unit test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  native-linux-unittests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install native toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++
+
+      - name: Build unit tests
+        working-directory: build
+        run: |
+          mkdir -p bin
+          g++ -c -std=c++11 -Wall -pedantic-errors -Wpedantic -Wconversion -DMOODYCAMEL_STATIC -pthread -g -O0 -fno-elide-constructors -fno-exceptions ../c_api/blockingconcurrentqueue.cpp ../c_api/concurrentqueue.cpp
+          g++ -std=c++11 -Wall -pedantic-errors -Wpedantic -Wconversion -DMOODYCAMEL_STATIC -pthread -g -O0 -fno-elide-constructors ../tests/common/simplethread.cpp ../tests/common/systemtime.cpp ../tests/unittests/unittests.cpp blockingconcurrentqueue.o concurrentqueue.o -o bin/unittests -lrt
+
+      - name: Run unit tests
+        working-directory: build
+        run: ./bin/unittests --disable-prompt --iterations 1
+
+  riscv64-linux-unittests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install RISC-V toolchain and QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-riscv64-linux-gnu qemu-user-static
+
+      - name: Build RISC-V unit tests
+        working-directory: build
+        run: |
+          mkdir -p bin-riscv
+          riscv64-linux-gnu-g++ -c -std=c++11 -Wall -pedantic-errors -Wpedantic -Wconversion -DMOODYCAMEL_STATIC -pthread -g -O0 -fno-elide-constructors -fno-exceptions ../c_api/blockingconcurrentqueue.cpp ../c_api/concurrentqueue.cpp
+          riscv64-linux-gnu-g++ -std=c++11 -Wall -pedantic-errors -Wpedantic -Wconversion -DMOODYCAMEL_STATIC -pthread -g -O0 -fno-elide-constructors ../tests/common/simplethread.cpp ../tests/common/systemtime.cpp ../tests/unittests/unittests.cpp blockingconcurrentqueue.o concurrentqueue.o -o bin-riscv/unittests-riscv64 -lrt
+
+      - name: Run RISC-V unit tests under QEMU
+        working-directory: build
+        run: qemu-riscv64-static -L /usr/riscv64-linux-gnu ./bin-riscv/unittests-riscv64 --disable-prompt --iterations 1

--- a/README.md
+++ b/README.md
@@ -455,8 +455,9 @@ core queue algorithm through the [CDSChecker][cdschecker] C++11 memory model mod
 inner algorithms were tested separately using the [Relacy][relacy] model checker, and full integration
 tests were also performed with Relacy.
 I've tested
-on Linux (Fedora 19) and Windows (7), but only on x86 processors so far (Intel and AMD). The code was
-written to be platform-independent, however, and should work across all processors and OSes.
+on Linux (Fedora 19) and Windows (7) on x86 processors (Intel and AMD), and the GitHub Actions CI now also
+cross-compiles and runs the unit tests for `riscv64` Linux under QEMU. The code was written to be
+platform-independent, and should work across all processors and OSes.
 
 Due to the complexity of the implementation and the difficult-to-test nature of lock-free code in general,
 there may still be bugs. If anyone is seeing buggy behaviour, I'd like to hear about it! (Especially if


### PR DESCRIPTION
## Why

`concurrentqueue` is already designed as a portable C++11 implementation and does not rely on architecture-specific assembly or SIMD backends in its core queue logic.

For this project, the missing part is not a new RISC-V code path in the library itself, but official verification coverage:

- the main implementation is intended to be portable, but that portability was not exercised by upstream CI;
- the repository already has a practical native unit test build flow, and it can also be cross-compiled for `riscv64` Linux and executed under QEMU without changing the queue algorithm;
- documenting `riscv64` support in the README is much more credible if the repository actually runs that verification automatically.

This patch keeps the lock-free implementation unchanged and turns the existing portability claim into a reproducible CI-backed test path.

## What changed

- Added `.github/workflows/ci.yml`:
  - build and run the unit tests on native `ubuntu-latest`;
  - cross-compile the same unit tests with `g++-riscv64-linux-gnu`;
  - run the resulting `riscv64` test binary under `qemu-riscv64-static`.
- Updated `README.md`:
  - replace the old “only on x86 processors so far” wording;
  - document that GitHub Actions now also cross-compiles and runs the unit tests for `riscv64` Linux under QEMU.

## Verification

- Verified native Windows rebuild and execution:
  - rebuilt `build/bin/unittests.exe` with the repository's existing command-line flow;
  - ran `.\build\bin\unittests.exe --disable-prompt --iterations 1`;
  - all tests passed.
- Verified workflow-equivalent Linux execution in Docker (`ubuntu:24.04`):
  - installed `g++`, `g++-riscv64-linux-gnu`, and `qemu-user-static`;
  - rebuilt and ran native Linux unit tests;
  - all tests passed.
- Verified real `riscv64` Linux cross-compilation and QEMU execution in Docker:
  - built `build/bin-riscv/unittests-riscv64` with `riscv64-linux-gnu-g++`;
  - ran it with `qemu-riscv64-static -L /usr/riscv64-linux-gnu`;
  - all tests passed.

## Notes

- This patch does not change the queue algorithm, memory ordering logic, or lock-free behavior.
- The goal is to upstream reproducible `riscv64` verification coverage for an already portable implementation, not to introduce a new RISC-V-specific optimization backend.