### PR TITLE
Use __has_feature(cxx_exceptions) to detect C++ exceptions on Clang

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -172,7 +172,14 @@ namespace moodycamel { namespace details {
 
 // Exceptions
 #ifndef MOODYCAMEL_EXCEPTIONS_ENABLED
-#if (defined(_MSC_VER) && defined(_CPPUNWIND)) || (defined(__GNUC__) && defined(__EXCEPTIONS)) || (!defined(_MSC_VER) && !defined(__GNUC__))
+// On Clang/AppleClang, __has_feature(cxx_exceptions) is the authoritative check
+// and correctly handles Objective-C++ where __EXCEPTIONS may be defined for
+// Objective-C exceptions even when C++ exceptions are disabled (see issue #435).
+#if defined(__has_feature)
+#if __has_feature(cxx_exceptions)
+#define MOODYCAMEL_EXCEPTIONS_ENABLED
+#endif
+#elif (defined(_MSC_VER) && defined(_CPPUNWIND)) || (defined(__GNUC__) && defined(__EXCEPTIONS)) || (!defined(_MSC_VER) && !defined(__GNUC__))
 #define MOODYCAMEL_EXCEPTIONS_ENABLED
 #endif
 #endif


### PR DESCRIPTION
### Problem

`MOODYCAMEL_EXCEPTIONS_ENABLED` is auto-detected from `__EXCEPTIONS` on Clang/GCC. On Clang, `__EXCEPTIONS` means "some exception handling is available" — it is set for **Objective-C exceptions even when C++ exceptions are disabled** (`-fno-exceptions`). Compiling an Objective-C++ (`.mm`) translation unit that includes `concurrentqueue.h` with `-fno-exceptions` therefore enables the C++ `throw`/`try` paths and fails to compile.

This is the case reported in #435.

### Fix

On compilers that provide `__has_feature` (Clang / AppleClang), use `__has_feature(cxx_exceptions)` — the authoritative query for whether **C++** exceptions are enabled — instead of `__EXCEPTIONS`. The existing MSVC/GCC predicate is kept as the fallback for compilers without `__has_feature`.

```cpp
#if defined(__has_feature)
#if __has_feature(cxx_exceptions)
#define MOODYCAMEL_EXCEPTIONS_ENABLED
#endif
#elif (defined(_MSC_VER) && defined(_CPPUNWIND)) || (defined(__GNUC__) && defined(__EXCEPTIONS)) || (!defined(_MSC_VER) && !defined(__GNUC__))
#define MOODYCAMEL_EXCEPTIONS_ENABLED
#endif
```

Behavior is unchanged on MSVC and GCC. On Clang, detection now tracks C++ exceptions specifically, so Objective-C++ with `-fno-exceptions` compiles correctly, and normal C++ builds with/without `-fno-exceptions` are detected as before. The user-overridable `MOODYCAMEL_EXCEPTIONS_ENABLED` escape hatch is untouched.

Refs #435.
