### PR TITLE
Fix CMake deprecation warnings and include paths (fixes #384, #391, #432)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ install(
                 lightweightsemaphore.h 
                 LICENSE.md
         DESTINATION 
-                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/moodycamel
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
 
 set(CPACK_PACKAGE_NAME ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.31)
 project(concurrentqueue VERSION 1.0.0)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
This PR resolves three open CMake-related issues:

1. **Fixes #432 (CMake deprecation warnings)**: Updates `cmake_minimum_required` to use the policy range syntax (`VERSION 3.9...3.31`). This silences the CMake deprecation warnings (e.g., "Compatibility with CMake < 3.10 will be removed") that occur in newer CMake versions, without breaking backward compatibility for users still on CMake 3.9.

2. **Fixes #384 and #391 (Mismatched include paths)**: Modifies the CMake install destination from `${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/moodycamel` to strictly `${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}`. This ensures that the physical installation path matches the `INSTALL_INTERFACE` expectations. Downstream projects using `find_package` will now correctly resolve `#include <concurrentqueue.h>` without needing the inverted `/moodycamel/` subdirectory prefix, which also aligns with vcpkg compatibility.

Both changes have been locally tested via `find_package` and `FetchContent` and compile cleanly.
